### PR TITLE
Make final field accessible too

### DIFF
--- a/core/src/main/java/moe/banana/jsonapi2/ResourceAdapter.java
+++ b/core/src/main/java/moe/banana/jsonapi2/ResourceAdapter.java
@@ -36,8 +36,8 @@ class ResourceAdapter<T extends Resource> extends JsonAdapter<T> {
                 // skip transient fields and static fields
                 continue;
             }
-            if (!Modifier.isPublic(modifiers)) {
-                // make private fields accessible
+            if (!Modifier.isPublic(modifiers) || Modifier.isFinal(modifiers)) {
+                // make private or final fields accessible
                 field.setAccessible(true);
             }
             String name = jsonNameMapping.getJsonName(field);


### PR DESCRIPTION
R8 make "final" some fields that are never set.

I can't use `proguard-android-optimize.txt` because of it.
`-allowaccessmodification` is causing issue with Kotlin data-class.