### PR TITLE
Double value should keep decimal portion calling fromJsonValue on JsonAdapter<Document>

### DIFF
--- a/core/src/test/java/moe/banana/jsonapi2/DocumentTest.java
+++ b/core/src/test/java/moe/banana/jsonapi2/DocumentTest.java
@@ -11,6 +11,8 @@ import org.junit.runners.MethodSorters;
 
 import java.io.EOFException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -344,6 +346,38 @@ public class DocumentTest {
         Document document = getDocumentAdapter(null)
                 .fromJson(TestUtil.fromResource("/meta.json"));
         assertThat(document.getMeta().get(TestUtil.moshi().adapter(Meta.class)), instanceOf(Meta.class));
+    }
+
+    @Test
+    public void deserialize_photo_from_value() {
+        Map<String, Object> photoMap = new HashMap();
+
+        Map<String, Object> linksNode = new HashMap();
+        linksNode.put("self", "http://example.com/photos/1");
+        photoMap.put("links", linksNode);
+
+        Map<String, Object> dataNode = new HashMap();
+        dataNode.put("type", "photos");
+        dataNode.put("id", "1");
+
+        Map<String, Object> attributesNode = new HashMap();
+        attributesNode.put("url", "http://photo.com/photo.jpg");
+        attributesNode.put("title", "My Photo");
+        attributesNode.put("color", "#EF5350");
+        attributesNode.put("shutter", 23.641);
+
+        Map<String, Object> locationNode = new HashMap();
+        locationNode.put("latitude", 39.9042);
+        locationNode.put("longitude", 116.4074);
+        attributesNode.put("location", locationNode);
+        dataNode.put("attributes", attributesNode);
+
+        photoMap.put("data", dataNode);
+
+        Document document = getDocumentAdapter(null, Photo.class).fromJsonValue(photoMap);
+        Photo photo = (Photo) document.asObjectDocument().get();
+        assertEquals(new Double(23.641), photo.getShutter());
+        assertEquals(new Double(39.9042), photo.getLocation().latitude);
     }
 
     @Test


### PR DESCRIPTION
Currently just a reproduction in a failing test.

The cause of of this issue is in the `dump(JsonReader reader, JsonWriter writer)` method in `MoshiHelper`

```
case NUMBER:
  try {
      writer.value(reader.nextLong());
  } catch (Exception ignored) {
      writer.value(reader.nextDouble());
  }
  break;
```

Typically this code is called with an instance `JsonUtf8Reader` and everything works fine in that case. In the case of the failing test in this PR, it's called with an instance of `JsonValueReader` instead. In `JsonValueReader.nextLong()`it essentially casts a double down to a long instead of throwing an exception.

I'm happy to implement a solution but would appreciate some guidance. The `dump` method could be changed to something like this:

```
case NUMBER:
  Double doubleValue = reader.nextDouble();
  if (Math.floor(doubleValue) == doubleValue) {
    writer.value((long)doubleValue);
  } else {
    writer.value(doubleValue);
  }
  break;
```

I think it would also be open to the thought that `JsonValueReader` should throw an exception if you call `nextLong()` when the value has a fractional part. If that is the preferred path, I can create an issue in the main moshi repo.

Thank you for moshi-jsonapi! Your work on it is much appreciated by the team at Yapp!